### PR TITLE
Use absolute class path when judging java code

### DIFF
--- a/trunk/build.gradle
+++ b/trunk/build.gradle
@@ -67,7 +67,8 @@ task generateMainPropertyFile(type: Exec) {
       file(staticResourcePath).absolutePath,
       file(imagesPath).absolutePath,
       file(dataPath).absolutePath,
-      file(uploadPath).absolutePath
+      file(uploadPath).absolutePath,
+      file(judgeWorkPath).absolutePath
 }
 
 task generateTestPropertyFile(type: Exec) {
@@ -78,7 +79,8 @@ task generateTestPropertyFile(type: Exec) {
       file(staticResourcePath).absolutePath,
       file(imagesPath).absolutePath,
       file(dataPath).absolutePath,
-      file(uploadPath).absolutePath
+      file(uploadPath).absolutePath,
+      file(judgeWorkPath).absolutePath
 }
 
 task cleanResources << {

--- a/trunk/gradle.properties
+++ b/trunk/gradle.properties
@@ -4,3 +4,4 @@ staticResourcePath = static/
 imagesPath = static/images/
 dataPath = data/data/
 uploadPath = data/upload/
+judgeWorkPath = work/

--- a/trunk/scripts/configure_project.sh
+++ b/trunk/scripts/configure_project.sh
@@ -12,8 +12,9 @@
 # $6 images path
 # $7 data path
 # $8 upload path
+# $9 judge work path
 
-if [ $# -ne 8 ]; then
+if [ $# -ne 9 ]; then
   exit 1
 fi
 
@@ -24,3 +25,4 @@ echo "staticResources.path=$5" >> $2
 echo "images.path=$6" >> $2
 echo "data.path=$7" >> $2
 echo "upload.path=$8" >> $2
+echo "judge.workPath=$9" >> $2

--- a/trunk/src/main/java/cn/edu/uestc/acmicpc/util/settings/Settings.java
+++ b/trunk/src/main/java/cn/edu/uestc/acmicpc/util/settings/Settings.java
@@ -101,7 +101,6 @@ public class Settings {
 
       // Judge settings
       JUDGE_CORE = getStringValueSettingByName(SettingsID.JUDGE_CORE);
-      WORK_PATH = getStringValueSettingByName(SettingsID.WORK_PATH);
       JUDGES = JSON.parseArray(getStringValueSettingByName(SettingsID.JUDGES), JudgeSetting.class);
 
       // Email settings
@@ -111,11 +110,13 @@ public class Settings {
       PICTURE_FOLDER = environment.getProperty("images.path") + "/";
       DATA_PATH = environment.getProperty("data.path") + "/";
       UPLOAD_FOLDER = environment.getProperty("upload.path") + "/";
+      WORK_PATH = environment.getProperty("judge.workPath") + "/";
 
       // Initialize folders
       FileUtil.createDirectoryIfNotExists(PICTURE_FOLDER);
       FileUtil.createDirectoryIfNotExists(DATA_PATH);
       FileUtil.createDirectoryIfNotExists(UPLOAD_FOLDER);
+      FileUtil.createDirectoryIfNotExists(WORK_PATH);
     } catch (AppException e) {
       e.printStackTrace();
     }

--- a/trunk/src/main/java/cn/edu/uestc/acmicpc/util/settings/SettingsID.java
+++ b/trunk/src/main/java/cn/edu/uestc/acmicpc/util/settings/SettingsID.java
@@ -10,7 +10,7 @@ public enum SettingsID {
   @Deprecated PICTURE_FOLDER(4),
   JUDGE_CORE(5),
   @Deprecated DATA_PATH(6),
-  WORK_PATH(7),
+  @Deprecated WORK_PATH(7),
   JUDGES(8),
   EMAIL(9),
   RECORD_PER_PAGE(10);


### PR DESCRIPTION
Modify `judgeWorkPath` in `gradle.properties` to change the judge's work path.
