### PR TITLE
change deprecated codes

### DIFF
--- a/trunk/build.gradle
+++ b/trunk/build.gradle
@@ -92,7 +92,7 @@ task generateTestPropertyFile(type: Exec) {
 }
 
 task cleanResources {
-    doLast {
+  doLast {
     delete "src/main/resources/resources.properties"
     delete "src/test/resources/resources.properties"
     delete "src/gen/"

--- a/trunk/build.gradle
+++ b/trunk/build.gradle
@@ -91,10 +91,12 @@ task generateTestPropertyFile(type: Exec) {
       file(judgeWorkPath).absolutePath
 }
 
-task cleanResources << {
-  delete "src/main/resources/resources.properties"
-  delete "src/test/resources/resources.properties"
-  delete "src/gen/"
+task cleanResources {
+    doLast {
+    delete "src/main/resources/resources.properties"
+    delete "src/test/resources/resources.properties"
+    delete "src/gen/"
+  }
 }
 
 checkDtosDoNotContainEntities.dependsOn(generateDtos)

--- a/trunk/static/build.gradle
+++ b/trunk/static/build.gradle
@@ -20,10 +20,12 @@ buildscript {
 }
 apply plugin: 'grunt'
 
-task build << {
-  nodeSetup.execute()
-  installGrunt.setArgs(['install', 'grunt-cli@1.1.0', 'grunt@~0.4.2'])
-  installGrunt.execute()
-  npmInstall.execute()
-  grunt_build.execute()
+task build {
+  doLast{
+    nodeSetup.execute()
+    installGrunt.setArgs(['install', 'grunt-cli@1.1.0', 'grunt@~0.4.2'])
+    installGrunt.execute()
+    npmInstall.execute()
+    grunt_build.execute()
+  }
 }


### PR DESCRIPTION
The Task.leftShift(Closure) method has been deprecated and is scheduled to be removed in Gradle 5.0.